### PR TITLE
Improve PACKAGE_TOP handling for S3DF

### DIFF
--- a/release.mak
+++ b/release.mak
@@ -4,8 +4,16 @@
 CPSW_VERSION           = R4.4.1
 CPSW_DEVICELIB_VERSION = R1.2.0
 
-# Package top
-PACKAGE_TOP      = /afs/slac/g/lcls/package
+# Location of packages. On S3DF, this should be defaulted to EPICS_PACKAGE_TOP. On AFS, we default to an absolute AFS path
+# This may also be provided on the command line or in the environment
+ifeq ($(PACKAGE_TOP),)
+ifneq ($(EPICS_PACKAGE_TOP),)
+	PACKAGE_TOP	= $(EPICS_PACKAGE_TOP)
+else
+	$(error PACKAGE_TOP or EPICS_PACKAGE_TOP must be provided in the environment or on the command line)
+endif
+endif
+
 # Packages location
 CPSW_DIR         = $(PACKAGE_TOP)/cpsw/framework/$(CPSW_VERSION)/src
 DEVICELIB_DIR    = $(PACKAGE_TOP)/cpsw/deviceLibrary/$(CPSW_DEVICELIB_VERSION)/$(TARCH)


### PR DESCRIPTION
Default `PACKAGE_TOP` more appropriately for S3DF, and allow it to be changed on the command line.